### PR TITLE
Make portfolio choice explicit when displaying stock details

### DIFF
--- a/stocktracker/urls.py
+++ b/stocktracker/urls.py
@@ -23,21 +23,24 @@ urlpatterns = [
     re_path(r'^api/', include('tracker_app.urls')),
     re_path(r'^admin/', admin.site.urls),
 
+    # updated stock data by ticker symbol
     re_path(r'^search/$', views.render_search_form, name='search-form'),
     re_path(r'^stocks/$', views.stock_index, name='stock-index'),
-    re_path(r'^stocks/(?P<symbol>.+)/$', views.stock_detail_for_seeded_portfolio, name='stock-detail-for-seeded-portfolio'),
+
+    # stock details for each stock in a given portfolio
+    re_path(r'^portfolios/(?P<pk>[0-9]+)/stocks/(?P<symbol>.+)/$', views.stock_detail_for_portfolio, name='portfolio-stock-detail'),
+
+    # remove stock from portfolio
     re_path(r'^stockDELETE/(?P<pk>[0-9]+)/$', views.delete_stock, name='delete-stock'),
 
+    # refresh price data in a given portfolio
+    re_path(r'^portfolio-refresh/(?P<pk>[0-9]+)/$', views.refresh_portfolio, name='refresh-portfolio'),
+
+    # dead code
     re_path(r'^stocksOLD/$', views.stockOLD_index, name='stockOLD-index'),
     re_path(r'^stocksOLD/(?P<pk>[0-9]+)/$', views.stockOLD_detail, name='stockOLD-detail'),
 
-    re_path(r'^portfolio-refresh/(?P<pk>[0-9]+)/$', views.refresh_portfolio, name='refresh-portfolio'),
-
-    # implement below for system with multiple portfolios
-    # re_path(r'^portfolios/$', views.portfolio_index, name='index'),
-    # re_path(r'^portfolios/(?P<pk>[0-9]+)/$', views.portfolio_detail, name='detail'),
-
-    # The root path displays the seeded portfolio detail
+    # At root path, display the seeded portfolio
     re_path(r'^$', views.view_seeded_portfolio, name='view-seeded-portfolio'),
 
 ]

--- a/tracker_app/templates/stocks/search_result.html
+++ b/tracker_app/templates/stocks/search_result.html
@@ -18,9 +18,8 @@
 
     <div id="addPortfolioDiv">
 
-        <form action="/stocks/{{symbol}}/" method="post">
+        <form action="/portfolios/{{ portfolio_id }}/stocks/{{symbol}}/" method="post">
             <input id="symbol" type="hidden" name="symbol" value="{{symbol}}">
-            <input id="portfolio_id" type="hidden" name="portfolio_id" value="{{ 1 }}">
             <input id="last_trade_price" type="hidden" name="last_trade_price" value={{closing_price}}>
             <input id="last_trade_time" type="hidden" name="last_trade_time" value={{latest_date_time}}>
 

--- a/tracker_app/tests/test_alphavantage_integration.py
+++ b/tracker_app/tests/test_alphavantage_integration.py
@@ -99,14 +99,6 @@ class AlphaVantageIntegrationTests(TestCase):
             stock = Stock.objects.get(symbol=symbol)
             self.assertEqual(stock.last_trade_price, Decimal(expected_price))
 
-    def test_refresh_portfolio_prices_when_portfolio_not_found(self):
-        """Test that refresh returns 404 for non-existent portfolio"""
-        non_existent_portfolio = 99999
-        url = reverse('refresh-portfolio', kwargs={'pk': non_existent_portfolio})
-        response = self.client.get(url)
-
-        self.assertEqual(response.status_code, 404)
-
     def _mock_single_stock_api_response(self, price):
         """Return mock response for a single stock API call."""
         mock_response = Mock()

--- a/tracker_app/tests/test_views.py
+++ b/tracker_app/tests/test_views.py
@@ -1,0 +1,115 @@
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from decimal import Decimal
+
+from ..models import Portfolio, Stock
+
+
+@override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage')
+class ViewErrorTests(TestCase):
+    """Tests for view error handling (404s, validation errors, etc.)"""
+
+    def setUp(self):
+        self.portfolio = Portfolio.objects.create(name="Test Portfolio")
+
+    def test_refresh_portfolio_returns_404_when_not_found(self):
+        """Test that refresh returns 404 for non-existent portfolio"""
+        non_existent_portfolio = 99999
+        url = reverse('refresh-portfolio', kwargs={'pk': non_existent_portfolio})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_stock_detail_returns_404_when_portfolio_not_found(self):
+        """Test that stock detail returns 404 for non-existent portfolio"""
+        non_existent_portfolio = 99999
+        url = f'/portfolios/{non_existent_portfolio}/stocks/AAPL/'
+        response = self.client.post(url, {
+            'last_trade_price': '150.00',
+            'last_trade_time': '2024-01-15 16:00:00',
+            'n_shares': '10',
+        })
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_stock_detail_error_when_duplicate_symbol(self):
+        """Test that adding a stock with duplicate symbol shows error message"""
+        # Create existing stock with symbol AAPL
+        Stock.objects.create(
+            symbol='AAPL',
+            portfolio=self.portfolio,
+            shares_owned=Decimal('10.000'),
+            last_trade_price=Decimal('150.00'),
+        )
+
+        # Try to add another stock with same symbol
+        url = f'/portfolios/{self.portfolio.pk}/stocks/AAPL/'
+        response = self.client.post(url, {
+            'last_trade_price': '155.00',
+            'last_trade_time': '2024-01-15 16:00:00',
+            'n_shares': '5',
+        })
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'stocks/search_form.html')
+        self.assertContains(response, "This stock is already in the portfolio. Please choose another.")
+
+    def test_stock_detail_error_when_portfolio_full(self):
+        """Test that adding a stock to a full portfolio (5 stocks) shows error message"""
+        # Create 5 stocks in portfolio
+        for i in range(5):
+            Stock.objects.create(
+                symbol=f'STK{i}',
+                portfolio=self.portfolio,
+                shares_owned=Decimal('10.000'),
+                last_trade_price=Decimal('100.00'),
+            )
+
+        # Try to add 6th stock
+        url = f'/portfolios/{self.portfolio.pk}/stocks/NEWSTOCK/'
+        response = self.client.post(url, {
+            'last_trade_price': '50.00',
+            'last_trade_time': '2024-01-15 16:00:00',
+            'n_shares': '10',
+        })
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'stocks/search_form.html')
+        self.assertContains(response, "This stock is already in the portfolio or the portfolio is full.")
+
+    def test_stock_detail_error_when_stock_already_in_portfolio(self):
+        """Test that adding a stock that already exists in portfolio shows error message"""
+        # Create a stock that's already in the portfolio
+        existing_stock = Stock.objects.create(
+            symbol='GOOGL',
+            portfolio=self.portfolio,
+            shares_owned=Decimal('5.000'),
+            last_trade_price=Decimal('140.00'),
+        )
+
+        # Create another stock with different symbol (not in any portfolio yet)
+        new_stock = Stock.objects.create(
+            symbol='MSFT',
+            portfolio=None,
+            shares_owned=Decimal('0.000'),
+            last_trade_price=Decimal('300.00'),
+        )
+
+        # Add the new stock to portfolio first
+        self.portfolio.add_stock(new_stock)
+
+        # Now try to add it again via the view - this will fail at add_stock
+        # because the stock is already in the portfolio
+        # Note: This test actually triggers the duplicate symbol error first
+        # because Stock has unique=True on symbol field
+        url = f'/portfolios/{self.portfolio.pk}/stocks/MSFT/'
+        response = self.client.post(url, {
+            'last_trade_price': '305.00',
+            'last_trade_time': '2024-01-15 16:00:00',
+            'n_shares': '10',
+        })
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'stocks/search_form.html')
+        # Will show duplicate symbol error since symbol is unique
+        self.assertContains(response, "This stock is already in the portfolio. Please choose another.")

--- a/tracker_app/views.py
+++ b/tracker_app/views.py
@@ -106,18 +106,25 @@ def stock_index(request):
     except Stock.DoesNotExist:
         pass
 
+    # Get seeded portfolio pk for the form action URL
+    seeded_portfolio = Portfolio.objects.get(name="Rainy Day Fund")
+
     context = {'symbol': symbol,
                'latest_date_time': latest_date_time,
                'closing_price': closing_price,
                'time_zone': time_zone,
-               'n_shares': n_shares}
+               'n_shares': n_shares,
+               'portfolio_id': seeded_portfolio.pk}
 
     return render(request, 'stocks/search_result.html', context)
 
 
 @csrf_exempt
-def stock_detail_for_seeded_portfolio(request, symbol):
-    portfolio = Portfolio.objects.get(name="Rainy Day Fund")
+def stock_detail_for_portfolio(request, pk, symbol):
+    try:
+        portfolio = Portfolio.objects.get(pk=pk)
+    except Portfolio.DoesNotExist:
+        raise Http404("Portfolio was not found in the database.")
 
     if request.method == 'POST':
         last_trade_price = request.POST.get('last_trade_price', None)


### PR DESCRIPTION
This does not remove hard-coding of a portfolio entirely. The hard-coding (in this PR) is moved deeper into the logic when searching/adding stocks. A subsequent PR will attempt to remove this hard-coding entirely.

This PR also adds a new level of testing (test_views.py) to ensure that the views are correctly handling error cases, returning the correct HTTP code. Views in django can be analogous to controllers.