### PR TITLE
Modify searching/adding stocks to reference the portfolio from which …

### DIFF
--- a/stocktracker/urls.py
+++ b/stocktracker/urls.py
@@ -27,6 +27,9 @@ urlpatterns = [
     re_path(r'^search/$', views.render_search_form, name='search-form'),
     re_path(r'^stocks/$', views.stock_index, name='stock-index'),
 
+    # view a specific portfolio
+    re_path(r'^portfolios/(?P<pk>[0-9]+)/$', views.view_portfolio, name='view-portfolio'),
+
     # stock details for each stock in a given portfolio
     re_path(r'^portfolios/(?P<pk>[0-9]+)/stocks/(?P<symbol>.+)/$', views.stock_detail_for_portfolio, name='portfolio-stock-detail'),
 

--- a/tracker_app/templates/base.html
+++ b/tracker_app/templates/base.html
@@ -45,13 +45,8 @@
 
 
           <section id="footer">
-              <div class="footline">
-                  <h6><a href="/search/">Search/Add Stocks</a></h6>
-              </div>
-
-              <div class="footline">
-                  <h6><a href="/">View Portfolio</a></h6>
-              </div>
+              {% block footerLinks %}
+              {% endblock %}
 
               <div class="footline">
                   <h6><a href="/api/" target="_blank">Browsable API</a></h6>

--- a/tracker_app/templates/portfolios/detail.html
+++ b/tracker_app/templates/portfolios/detail.html
@@ -48,3 +48,9 @@
     </div>
 
 {% endblock %}
+
+{% block footerLinks %}
+    <div class="footline">
+        <h6><a href="/search/?portfolio_id={{ portfolio.pk }}">Search/Add Stocks</a></h6>
+    </div>
+{% endblock %}

--- a/tracker_app/templates/stocks/search_form.html
+++ b/tracker_app/templates/stocks/search_form.html
@@ -9,12 +9,19 @@
         <div class="stockDetail" id="stockLabels"></div>
 
         <div class="stockDetail">
-              <form action="/stocks/{{symbol}}" method="get">
+              <form action="/stocks/" method="get">
+                <input type="hidden" name="portfolio_id" value="{{ portfolio_id }}">
                 <label for "symbol">Enter symbol here: </label>
                 <input id="symbol" type="text" name="symbol">
                 <input type="submit" value="Find it!" />
               </form>
         </div>
 
+    </div>
+{% endblock %}
+
+{% block footerLinks %}
+    <div class="footline">
+        <h6><a href="/portfolios/{{ portfolio_id }}/">View Portfolio</a></h6>
     </div>
 {% endblock %}

--- a/tracker_app/templates/stocks/search_result.html
+++ b/tracker_app/templates/stocks/search_result.html
@@ -32,3 +32,9 @@
         </form>
     </div>
 {% endblock %}
+
+{% block footerLinks %}
+    <div class="footline">
+        <h6><a href="/portfolios/{{ portfolio_id }}/">View Portfolio</a></h6>
+    </div>
+{% endblock %}

--- a/tracker_app/tests/test_alphavantage_integration.py
+++ b/tracker_app/tests/test_alphavantage_integration.py
@@ -42,7 +42,7 @@ class AlphaVantageIntegrationTests(TestCase):
 
         # Call method under test
         url = reverse('stock-index')
-        response = self.client.get(url, {'symbol': ticker_symbol})
+        response = self.client.get(url, {'symbol': ticker_symbol, 'portfolio_id': self.portfolio.pk})
 
         # Verify view returns 200
         self.assertEqual(response.status_code, 200)
@@ -114,6 +114,28 @@ class AlphaVantageIntegrationTests(TestCase):
             }
         })
         return mock_response
+
+    @patch('tracker_app.views.requests.get')
+    def test_stock_index_handles_api_error(self, mock_get):
+        """Test that stock search handles API errors gracefully"""
+        ticker_symbol = 'AAPL'
+
+        # Mock API response without 'Meta Data' (simulating rate limit error)
+        mock_response = Mock()
+        mock_response.text = json.dumps({
+            'Note': 'Thank you for using Alpha Vantage! Our standard API rate limit is 25 requests per day.'
+        })
+        mock_get.return_value = mock_response
+
+        # Call stock index
+        url = reverse('stock-index')
+        response = self.client.get(url, {'symbol': ticker_symbol, 'portfolio_id': self.portfolio.pk})
+
+        # Verify returns to search form with error message
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'stocks/search_form.html')
+        self.assertContains(response, "exceeded the request limit for the free equity lookup service")
+        self.assertEqual(response.context['portfolio_id'], str(self.portfolio.pk))
 
     def _mock_api_response_by_symbol(self, prices_by_symbol):
         """Return a function that returns mock API responses based on symbol in URL."""

--- a/tracker_app/tests/test_templates.py
+++ b/tracker_app/tests/test_templates.py
@@ -54,8 +54,7 @@ class PortfolioTemplateTests(TestCase):
         response = self.client.get('/')
 
         self.assertContains(response, f'<a href="/portfolio-refresh/{self.portfolio.pk}/">Refresh Prices</a>')
-        self.assertContains(response, '<a href="/search/">Search/Add Stocks</a>')
-        self.assertContains(response, '<a href="/">View Portfolio</a>')
+        self.assertContains(response, f'<a href="/search/?portfolio_id={self.portfolio.pk}">Search/Add Stocks</a>')
         self.assertContains(response, '<a href="/api/" target="_blank">Browsable API</a>')
 
     def test_root_url_displays_stock_data(self):
@@ -85,10 +84,10 @@ class PortfolioTemplateTests(TestCase):
         response = self.client.get(f'/portfolio-refresh/{self.portfolio.pk}/')
 
         # Verify that user is redirected back to portfolio view
-        self.assertRedirects(response, '/')
+        self.assertRedirects(response, f'/portfolios/{self.portfolio.pk}/')
 
         # Verify that user sees updated prices on the page
-        response = self.client.get('/')
+        response = self.client.get(f'/portfolios/{self.portfolio.pk}/')
         for price in new_prices_by_symbol.values():
             self.assertContains(response, price)
 

--- a/tracker_app/tests/test_views.py
+++ b/tracker_app/tests/test_views.py
@@ -1,6 +1,8 @@
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from decimal import Decimal
+from unittest.mock import patch, Mock
+import json
 
 from ..models import Portfolio, Stock
 
@@ -53,6 +55,7 @@ class ViewErrorTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'stocks/search_form.html')
         self.assertContains(response, "This stock is already in the portfolio. Please choose another.")
+        self.assertEqual(int(response.context['portfolio_id']), self.portfolio.pk)
 
     def test_stock_detail_error_when_portfolio_full(self):
         """Test that adding a stock to a full portfolio (5 stocks) shows error message"""
@@ -76,6 +79,7 @@ class ViewErrorTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'stocks/search_form.html')
         self.assertContains(response, "This stock is already in the portfolio or the portfolio is full.")
+        self.assertEqual(int(response.context['portfolio_id']), self.portfolio.pk)
 
     def test_stock_detail_error_when_stock_already_in_portfolio(self):
         """Test that adding a stock that already exists in portfolio shows error message"""
@@ -113,3 +117,32 @@ class ViewErrorTests(TestCase):
         self.assertTemplateUsed(response, 'stocks/search_form.html')
         # Will show duplicate symbol error since symbol is unique
         self.assertContains(response, "This stock is already in the portfolio. Please choose another.")
+        self.assertEqual(int(response.context['portfolio_id']), self.portfolio.pk)
+
+    @patch('tracker_app.views.requests.get')
+    def test_refresh_portfolio_handles_api_error(self, mock_get):
+        """Test that refresh portfolio handles API errors gracefully"""
+        # Create a stock in the portfolio
+        Stock.objects.create(
+            symbol='AAPL',
+            portfolio=self.portfolio,
+            shares_owned=Decimal('10.000'),
+            last_trade_price=Decimal('150.00'),
+        )
+
+        # Mock API response without 'Meta Data' (simulating rate limit error)
+        mock_response = Mock()
+        mock_response.text = json.dumps({
+            'Note': 'Thank you for using Alpha Vantage! Our standard API rate limit is 25 requests per day.'
+        })
+        mock_get.return_value = mock_response
+
+        # Call refresh portfolio
+        url = reverse('refresh-portfolio', kwargs={'pk': self.portfolio.pk})
+        response = self.client.get(url)
+
+        # Verify stays on portfolio page with error message
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'portfolios/detail.html')
+        self.assertContains(response, "exceeded the request limit for the free equity lookup service")
+        self.assertEqual(response.context['portfolio'].pk, self.portfolio.pk)

--- a/tracker_app/views.py
+++ b/tracker_app/views.py
@@ -56,6 +56,17 @@ def view_seeded_portfolio(request):
         raise Http404("Seeded portfolio was not found in the database.")
 
 
+def view_portfolio(request, pk):
+    try:
+        portfolio = Portfolio.objects.get(pk=pk)
+    except Portfolio.DoesNotExist:
+        raise Http404("Portfolio not found.")
+
+    stock_queryset = portfolio.stock_set.all()
+    context = {'portfolio': portfolio, 'stock_set': stock_queryset}
+    return render(request, 'portfolios/detail.html', context)
+
+
 def refresh_portfolio(request, pk):
     try:
         portfolio = Portfolio.objects.get(pk=pk)
@@ -69,6 +80,13 @@ def refresh_portfolio(request, pk):
         response = requests.get(api_call)
         stock_text = response.text
         stock_dict = json.loads(stock_text)
+
+        if 'Meta Data' not in stock_dict:
+            # API error (rate limiting, invalid key, etc.)
+            error_msg = "Today, we've exceeded the request limit for the free equity lookup service that this application uses. Sorry for the inconvenience. Please try again later."
+            context = {'portfolio': portfolio, 'stock_set': stock_queryset, 'error_message': error_msg}
+            return render(request, 'portfolios/detail.html', context)
+
         meta_data = stock_dict['Meta Data']
 
         time_zone = meta_data['6. Time Zone']
@@ -82,17 +100,27 @@ def refresh_portfolio(request, pk):
 
         stock.save()
 
-    return redirect('/')
+    return redirect(f'/portfolios/{pk}/')
 
 def render_search_form(request):
-    return render(request, 'stocks/search_form.html')
+    portfolio_id = request.GET.get('portfolio_id', None)
+    context = {'portfolio_id': portfolio_id}
+    return render(request, 'stocks/search_form.html', context)
 
 def stock_index(request):
     symbol = request.GET.get('symbol', None)
+    portfolio_id = request.GET.get('portfolio_id', None)
+
     api_call = "https://www.alphavantage.co/query?function=TIME_SERIES_INTRADAY&symbol={0}&interval=1min&apikey={1}".format(symbol, settings.ALPHA_KEY)
     response = requests.get(api_call)
     stock_text = response.text
     stock_dict = json.loads(stock_text)
+
+    if 'Meta Data' not in stock_dict:
+        # API error (rate limiting, invalid key, etc.)
+        error_msg = "Today, we've exceeded the request limit for the free equity lookup service that this application uses. Sorry for the inconvenience. Please try again later."
+        context = {'error_message': error_msg, 'portfolio_id': portfolio_id}
+        return render(request, 'stocks/search_form.html', context)
 
     meta_data = stock_dict['Meta Data']
     time_zone = meta_data['6. Time Zone']
@@ -106,15 +134,12 @@ def stock_index(request):
     except Stock.DoesNotExist:
         pass
 
-    # Get seeded portfolio pk for the form action URL
-    seeded_portfolio = Portfolio.objects.get(name="Rainy Day Fund")
-
     context = {'symbol': symbol,
                'latest_date_time': latest_date_time,
                'closing_price': closing_price,
                'time_zone': time_zone,
                'n_shares': n_shares,
-               'portfolio_id': seeded_portfolio.pk}
+               'portfolio_id': portfolio_id}
 
     return render(request, 'stocks/search_result.html', context)
 
@@ -137,12 +162,12 @@ def stock_detail_for_portfolio(request, pk, symbol):
         try:
             new_stock.save()
         except Exception:
-            return render(request, 'stocks/search_form.html', { 'error_message' : "This stock is already in the portfolio. Please choose another."})
+            return render(request, 'stocks/search_form.html', { 'error_message' : "This stock is already in the portfolio. Please choose another.", 'portfolio_id': pk})
 
         try:
             portfolio.add_stock(new_stock)
         except Exception:
-            return render(request, 'stocks/search_form.html', { 'error_message' : "This stock is already in the portfolio or the portfolio is full."})
+            return render(request, 'stocks/search_form.html', { 'error_message' : "This stock is already in the portfolio or the portfolio is full.", 'portfolio_id': pk})
 
         new_stock.buy_shares(n_shares)
 


### PR DESCRIPTION
…that page was accessed.

This removes the most aggregious remaining hard-coded reference to the seeded portfolio. (The root url still references the seeded portfolio for the landing page view, which is intentional to unify the experience of users viewing the app for the first time.)

This change required moving a couple of global navigation buttons into non-global templates/views becuse those buttons now require knowledge of the relevant portfolio.