### PR TITLE
Correct the template routing for update and delete of stock

### DIFF
--- a/stocktracker/urls.py
+++ b/stocktracker/urls.py
@@ -36,6 +36,9 @@ urlpatterns = [
     # remove stock from portfolio
     re_path(r'^stock-delete/(?P<pk>[0-9]+)/$', views.delete_stock, name='delete-stock'),
 
+    # update shares of stock in portfolio
+    re_path(r'^stock-update/(?P<pk>[0-9]+)/$', views.update_stock_shares, name='stock-update'),
+
     # refresh price data in a given portfolio
     re_path(r'^portfolio-refresh/(?P<pk>[0-9]+)/$', views.refresh_portfolio, name='refresh-portfolio'),
 

--- a/tracker_app/templates/portfolios/detail.html
+++ b/tracker_app/templates/portfolios/detail.html
@@ -30,14 +30,16 @@
                   <p>{{ stock.last_trade_time }}</p>
                   <p>{{ stock.last_trade_price|floatformat:2 }}</p>
 
-                  <form action="/api/stocks/{{stock.id}}/" method='put'>
+                  <form action="{% url 'stock-update' stock.id %}" method="post">
+                      {% csrf_token %}
                       <input id="n_shares" type="text" name="n_shares" value="{{stock.shares_owned|floatformat:2}}">
                       <input type="submit" value="Update">
                   </form>
 
                   <p>{{ stock.last_trade_price|multiply:stock.shares_owned|floatformat:2 }}</p>
 
-                  <form action="/stock-delete/{{stock.id}}/" method="delete">
+                  <form action="{% url 'delete-stock' stock.id %}" method="post">
+                      {% csrf_token %}
                       <input type="submit" value="Remove from Portfolio">
                   </form>
             </div>

--- a/tracker_app/tests/test_views.py
+++ b/tracker_app/tests/test_views.py
@@ -146,3 +146,184 @@ class ViewErrorTests(TestCase):
         self.assertTemplateUsed(response, 'portfolios/detail.html')
         self.assertContains(response, "exceeded the request limit for the free equity lookup service")
         self.assertEqual(response.context['portfolio'].pk, self.portfolio.pk)
+
+
+@override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage')
+class StockUpdateViewTests(TestCase):
+    """Tests for stock update view functionality"""
+
+    def setUp(self):
+        self.portfolio = Portfolio.objects.create(name="Test Portfolio")
+        self.stock = Stock.objects.create(
+            symbol='AAPL',
+            portfolio=self.portfolio,
+            shares_owned=Decimal('10.000'),
+            last_trade_price=Decimal('150.00'),
+        )
+
+    def test_update_stock_shares_success(self):
+        """Test successful update of stock shares"""
+        url = reverse('stock-update', kwargs={'pk': self.stock.pk})
+        response = self.client.post(url, {'n_shares': '25.5'})
+
+        # Should redirect to portfolio detail page
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, reverse('view-portfolio', kwargs={'pk': self.portfolio.pk}))
+
+        # Verify shares were updated in database
+        self.stock.refresh_from_db()
+        self.assertEqual(self.stock.shares_owned, Decimal('25.500'))
+
+    def test_update_stock_shares_redirects_to_portfolio(self):
+        """Test that update redirects back to the correct portfolio page"""
+        url = reverse('stock-update', kwargs={'pk': self.stock.pk})
+        response = self.client.post(url, {'n_shares': '15'})
+
+        self.assertRedirects(response, f'/portfolios/{self.portfolio.pk}/')
+
+    def test_update_stock_returns_404_when_not_found(self):
+        """Test that update returns 404 for non-existent stock"""
+        non_existent_stock = 99999
+        url = reverse('stock-update', kwargs={'pk': non_existent_stock})
+        response = self.client.post(url, {'n_shares': '10'})
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_update_stock_handles_invalid_shares_value(self):
+        """Test that update handles invalid (non-numeric) shares value gracefully"""
+        url = reverse('stock-update', kwargs={'pk': self.stock.pk})
+        original_shares = self.stock.shares_owned
+
+        response = self.client.post(url, {'n_shares': 'invalid'})
+
+        # Should still redirect (graceful handling)
+        self.assertEqual(response.status_code, 302)
+
+        # Shares should remain unchanged
+        self.stock.refresh_from_db()
+        self.assertEqual(self.stock.shares_owned, original_shares)
+
+    def test_update_stock_handles_missing_shares_value(self):
+        """Test that update handles missing n_shares parameter gracefully"""
+        url = reverse('stock-update', kwargs={'pk': self.stock.pk})
+        original_shares = self.stock.shares_owned
+
+        response = self.client.post(url, {})
+
+        # Should still redirect (graceful handling)
+        self.assertEqual(response.status_code, 302)
+
+        # Shares should remain unchanged
+        self.stock.refresh_from_db()
+        self.assertEqual(self.stock.shares_owned, original_shares)
+
+    def test_update_stock_handles_decimal_precision(self):
+        """Test that update correctly handles decimal precision"""
+        url = reverse('stock-update', kwargs={'pk': self.stock.pk})
+        response = self.client.post(url, {'n_shares': '123.456789'})
+
+        self.assertEqual(response.status_code, 302)
+
+        # Should be rounded to 3 decimal places
+        self.stock.refresh_from_db()
+        self.assertEqual(self.stock.shares_owned, Decimal('123.457'))
+
+    def test_update_stock_via_get_does_not_modify(self):
+        """Test that GET request does not modify shares"""
+        url = reverse('stock-update', kwargs={'pk': self.stock.pk})
+        original_shares = self.stock.shares_owned
+
+        response = self.client.get(url, {'n_shares': '999'})
+
+        # Should redirect but not modify
+        self.assertEqual(response.status_code, 302)
+
+        # Shares should remain unchanged
+        self.stock.refresh_from_db()
+        self.assertEqual(self.stock.shares_owned, original_shares)
+
+    def test_update_stock_redirects_to_root_if_no_portfolio(self):
+        """Test that update redirects to root if stock has no portfolio"""
+        orphan_stock = Stock.objects.create(
+            symbol='ORPHAN',
+            portfolio=None,
+            shares_owned=Decimal('5.000'),
+            last_trade_price=Decimal('50.00'),
+        )
+        url = reverse('stock-update', kwargs={'pk': orphan_stock.pk})
+        response = self.client.post(url, {'n_shares': '10'})
+
+        # Check redirect without following (root view requires seeded portfolio)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, '/')
+
+
+@override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage')
+class StockDeleteViewTests(TestCase):
+    """Tests for stock delete view functionality"""
+
+    def setUp(self):
+        self.portfolio = Portfolio.objects.create(name="Test Portfolio")
+        self.stock = Stock.objects.create(
+            symbol='AAPL',
+            portfolio=self.portfolio,
+            shares_owned=Decimal('10.000'),
+            last_trade_price=Decimal('150.00'),
+        )
+
+    def test_delete_stock_success(self):
+        """Test successful deletion of stock via POST"""
+        url = reverse('delete-stock', kwargs={'pk': self.stock.pk})
+        stock_pk = self.stock.pk
+
+        response = self.client.post(url)
+
+        # Should redirect to portfolio detail page
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, reverse('view-portfolio', kwargs={'pk': self.portfolio.pk}))
+
+        # Verify stock was deleted from database
+        self.assertFalse(Stock.objects.filter(pk=stock_pk).exists())
+
+    def test_delete_stock_redirects_to_portfolio(self):
+        """Test that delete redirects back to the correct portfolio page"""
+        url = reverse('delete-stock', kwargs={'pk': self.stock.pk})
+        response = self.client.post(url)
+
+        self.assertRedirects(response, f'/portfolios/{self.portfolio.pk}/')
+
+    def test_delete_stock_returns_404_when_not_found(self):
+        """Test that delete returns 404 for non-existent stock"""
+        non_existent_stock = 99999
+        url = reverse('delete-stock', kwargs={'pk': non_existent_stock})
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_delete_stock_via_get_does_not_modify(self):
+        """Test that GET request does not delete stock"""
+        url = reverse('delete-stock', kwargs={'pk': self.stock.pk})
+        stock_pk = self.stock.pk
+
+        response = self.client.get(url)
+
+        # Should redirect but not delete
+        self.assertEqual(response.status_code, 302)
+
+        # Stock should still exist
+        self.assertTrue(Stock.objects.filter(pk=stock_pk).exists())
+
+    def test_delete_stock_redirects_to_root_if_no_portfolio(self):
+        """Test that delete redirects to root if stock has no portfolio"""
+        orphan_stock = Stock.objects.create(
+            symbol='ORPHAN',
+            portfolio=None,
+            shares_owned=Decimal('5.000'),
+            last_trade_price=Decimal('50.00'),
+        )
+        url = reverse('delete-stock', kwargs={'pk': orphan_stock.pk})
+        response = self.client.post(url)
+
+        # Check redirect without following (root view requires seeded portfolio)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, '/')

--- a/tracker_app/views.py
+++ b/tracker_app/views.py
@@ -195,19 +195,43 @@ def stock_detail_for_portfolio(request, pk, symbol):
     context = {'portfolio': portfolio, 'stock_set': stock_queryset}
     return redirect('/')
 
-@csrf_exempt
 def delete_stock(request, pk):
-    stock_to_delete = Stock.objects.get(pk=pk)
-    stock_to_delete.remove_from_portfolio()
-    stock_to_delete.delete()
+    try:
+        stock = Stock.objects.get(pk=pk)
+    except Stock.DoesNotExist:
+        raise Http404("Stock not found.")
+
+    portfolio_pk = stock.portfolio.pk if stock.portfolio else None
+
+    if request.method == 'POST':
+        stock.remove_from_portfolio()
+        stock.delete()
+
+    # Redirect back to the portfolio detail page
+    if portfolio_pk:
+        return redirect('view-portfolio', pk=portfolio_pk)
     return redirect('/')
 
-# @csrf_exempt
-# def update_stock(request, pk):
-#     new_number_of_shares = request.POST.get('n_shares', None)
-#     stock_to_update = Stock.objects.get(pk=pk)
-#     stock_to_update.shares_owned = new_number_of_shares
-#     return redirect('/')
+
+def update_stock_shares(request, pk):
+    try:
+        stock = Stock.objects.get(pk=pk)
+    except Stock.DoesNotExist:
+        raise Http404("Stock not found.")
+
+    if request.method == 'POST':
+        new_shares = request.POST.get('n_shares', None)
+        if new_shares is not None:
+            try:
+                stock.shares_owned = round(float(new_shares), 3)
+                stock.save()
+            except (ValueError, TypeError):
+                pass  # Invalid input, don't update
+
+    # Redirect back to the portfolio detail page
+    if stock.portfolio:
+        return redirect('view-portfolio', pk=stock.portfolio.pk)
+    return redirect('/')
 
 
 


### PR DESCRIPTION
This change corrects an error in routing which was using an api route instead of a template route. It also strengthens the security on the update and delete path (blocks injection via get request).